### PR TITLE
Feature/sort filters alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 0.0.3 (in development)
+* Sort the categorical filter options alphabetically.
 
 ## 0.0.2 (2025-05-17)
 Add new capabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.0.3 (in development)
-* Sort the categorical filter options alphabetically.
+* [#2](https://github.com/sbslee/streamlit-excel/issues/2): Sort the categorical filter options alphabetically.
 
 ## 0.0.2 (2025-05-17)
 Add new capabilities.

--- a/streamlit_excel/__init__.py
+++ b/streamlit_excel/__init__.py
@@ -101,7 +101,7 @@ class Table:
             else:
                 st.warning(f"Column is not currently filtered.")
 
-        observed_options = self._get_unique(self.view[column])
+        observed_options = sorted(self._get_unique(self.view[column]))
         default_options = self._get_default_options(column, "selected_options", observed_options, self._select_all)
 
         with st.form(f"{self.key}_{column}", border=False):

--- a/streamlit_excel/__init__.py
+++ b/streamlit_excel/__init__.py
@@ -78,7 +78,7 @@ class Table:
         if select_all:
             default_options = observed_options
         elif column in self.data:
-            default_options = list(set(self.data[column][target]) & set(observed_options))
+            default_options = sorted(list(set(self.data[column][target]) & set(observed_options)))
         else:
             default_options = None
         return default_options


### PR DESCRIPTION
- Sort the categorical filter options alphabetically to enhance user experience.
- After applying user filters, the next time the user opens the filter form widget, the `default_options` are not shown in alphabetical order, so apply sorting there as well to maintain consistency.
